### PR TITLE
update to embedded-hal 1.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, beta, 1.65.0]
+        rust: [stable, beta, 1.81.0]
         TARGET:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.73.0
+          toolchain: 1.82.0
           targets: x86_64-unknown-linux-gnu
           components: clippy
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Changed
-- Raise MSRV to 1.65.0.
+- Raise MSRV to 1.81.0.
+- Update to embedded-hal 1.0
 
 ## [0.2.0] - 2021-04-05
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ include = [
 ]
 
 [dependencies]
-embedded-hal = "0.2.7"
+embedded-hal = "1.0"
 
 [dev-dependencies]
 linux-embedded-hal = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ include = [
 embedded-hal = "1.0"
 
 [dev-dependencies]
-linux-embedded-hal = "0.3"
-embedded-hal-mock = "0.9"
+linux-embedded-hal = "0.4"
+embedded-hal-mock = "0.10"
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ fn main() {
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.65.0 and up. It *might*
+This crate is guaranteed to compile on stable Rust 1.81.0 and up. It *might*
 compile with older versions but that may change in any new patch release.
 
 ## Support

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -71,6 +71,7 @@ where
     /// - If *wait long* is enabled, then the wait time is increased by a
     ///   factor of 12 and therefore corresponds to aproximately:
     ///   `number_of_cycles * 0.029s`.
+    ///
     /// See [`enable_wait_long()`](#method.enable_wait_long) and
     ///  [`disable_wait_long()`](#method.disable_wait_long).
     pub fn set_wait_cycles(&mut self, cycles: u16) -> Result<(), Error<I2C::Error>> {
@@ -120,12 +121,18 @@ where
     }
 
     /// Set the RGB converter interrupt clear channel low threshold.
-    pub fn set_rgbc_interrupt_low_threshold(&mut self, threshold: u16) -> Result<(), Error<I2C::Error>> {
+    pub fn set_rgbc_interrupt_low_threshold(
+        &mut self,
+        threshold: u16,
+    ) -> Result<(), Error<I2C::Error>> {
         self.write_registers(Register::AILTL, threshold as u8, (threshold >> 8) as u8)
     }
 
     /// Set the RGB converter interrupt clear channel high threshold.
-    pub fn set_rgbc_interrupt_high_threshold(&mut self, threshold: u16) -> Result<(), Error<I2C::Error>> {
+    pub fn set_rgbc_interrupt_high_threshold(
+        &mut self,
+        threshold: u16,
+    ) -> Result<(), Error<I2C::Error>> {
         self.write_registers(Register::AIHTL, threshold as u8, (threshold >> 8) as u8)
     }
 
@@ -164,7 +171,12 @@ where
             .map_err(Error::I2C)
     }
 
-    fn write_registers(&mut self, register: u8, value0: u8, value1: u8) -> Result<(), Error<I2C::Error>> {
+    fn write_registers(
+        &mut self,
+        register: u8,
+        value0: u8,
+        value1: u8,
+    ) -> Result<(), Error<I2C::Error>> {
         let command = BitFlags::CMD | BitFlags::CMD_AUTO_INC | register;
         self.i2c
             .write(DEVICE_ADDRESS, &[command, value0, value1])

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -3,61 +3,61 @@ use crate::{
 };
 use embedded_hal::i2c;
 
-impl<I2C, E> Tcs3472<I2C>
+impl<I2C> Tcs3472<I2C>
 where
-    I2C: i2c::I2c<Error = E>,
+    I2C: i2c::I2c,
 {
     /// Enable the device (Power ON).
     ///
     /// The device goes to idle state.
-    pub fn enable(&mut self) -> Result<(), Error<E>> {
+    pub fn enable(&mut self) -> Result<(), Error<I2C::Error>> {
         let enable = self.enable;
         self.write_enable(enable | BitFlags::POWER_ON)
     }
 
     /// Disable the device (sleep).
-    pub fn disable(&mut self) -> Result<(), Error<E>> {
+    pub fn disable(&mut self) -> Result<(), Error<I2C::Error>> {
         let enable = self.enable;
         self.write_enable(enable & !BitFlags::POWER_ON)
     }
 
     /// Enable the RGB converter.
-    pub fn enable_rgbc(&mut self) -> Result<(), Error<E>> {
+    pub fn enable_rgbc(&mut self) -> Result<(), Error<I2C::Error>> {
         let enable = self.enable;
         self.write_enable(enable | BitFlags::RGBC_EN)
     }
 
     /// Disable the RGB converter.
-    pub fn disable_rgbc(&mut self) -> Result<(), Error<E>> {
+    pub fn disable_rgbc(&mut self) -> Result<(), Error<I2C::Error>> {
         let enable = self.enable;
         self.write_enable(enable & !BitFlags::RGBC_EN)
     }
 
     /// Enable the RGB converter interrupt generation.
-    pub fn enable_rgbc_interrupts(&mut self) -> Result<(), Error<E>> {
+    pub fn enable_rgbc_interrupts(&mut self) -> Result<(), Error<I2C::Error>> {
         let enable = self.enable;
         self.write_enable(enable | BitFlags::RGBC_INT_EN)
     }
 
     /// Disable the RGB converter interrupt generation.
-    pub fn disable_rgbc_interrupts(&mut self) -> Result<(), Error<E>> {
+    pub fn disable_rgbc_interrupts(&mut self) -> Result<(), Error<I2C::Error>> {
         let enable = self.enable;
         self.write_enable(enable & !BitFlags::RGBC_INT_EN)
     }
 
     /// Enable the wait feature (wait timer).
-    pub fn enable_wait(&mut self) -> Result<(), Error<E>> {
+    pub fn enable_wait(&mut self) -> Result<(), Error<I2C::Error>> {
         let enable = self.enable;
         self.write_enable(enable | BitFlags::WAIT_EN)
     }
 
     /// Disable the wait feature (wait timer).
-    pub fn disable_wait(&mut self) -> Result<(), Error<E>> {
+    pub fn disable_wait(&mut self) -> Result<(), Error<I2C::Error>> {
         let enable = self.enable;
         self.write_enable(enable & !BitFlags::WAIT_EN)
     }
 
-    fn write_enable(&mut self, enable: u8) -> Result<(), Error<E>> {
+    fn write_enable(&mut self, enable: u8) -> Result<(), Error<I2C::Error>> {
         self.write_register(Register::ENABLE, enable)?;
         self.enable = enable;
         Ok(())
@@ -73,7 +73,7 @@ where
     ///   `number_of_cycles * 0.029s`.
     /// See [`enable_wait_long()`](#method.enable_wait_long) and
     ///  [`disable_wait_long()`](#method.disable_wait_long).
-    pub fn set_wait_cycles(&mut self, cycles: u16) -> Result<(), Error<E>> {
+    pub fn set_wait_cycles(&mut self, cycles: u16) -> Result<(), Error<I2C::Error>> {
         if cycles > 256 || cycles == 0 {
             return Err(Error::InvalidInputData);
         }
@@ -85,7 +85,7 @@ where
     ///
     /// The wait time configured with `set_wait_cycles()` is increased by a
     /// factor of 12. See [`set_wait_cycles()`](#method.set_wait_cycles).
-    pub fn enable_wait_long(&mut self) -> Result<(), Error<E>> {
+    pub fn enable_wait_long(&mut self) -> Result<(), Error<I2C::Error>> {
         self.write_register(Register::CONFIG, BitFlags::WLONG)
     }
 
@@ -93,12 +93,12 @@ where
     ///
     /// The wait time configured with `set_wait_cycles()` is used without
     /// multiplication factor. See [`set_wait_cycles()`](#method.set_wait_cycles).
-    pub fn disable_wait_long(&mut self) -> Result<(), Error<E>> {
+    pub fn disable_wait_long(&mut self) -> Result<(), Error<I2C::Error>> {
         self.write_register(Register::CONFIG, 0)
     }
 
     /// Set the RGB converter gain.
-    pub fn set_rgbc_gain(&mut self, gain: RgbCGain) -> Result<(), Error<E>> {
+    pub fn set_rgbc_gain(&mut self, gain: RgbCGain) -> Result<(), Error<I2C::Error>> {
         // Register field: AGAIN
         match gain {
             RgbCGain::_1x => self.write_register(Register::CONTROL, 0),
@@ -111,7 +111,7 @@ where
     /// Set the number of integration cycles (1-256).
     ///
     /// The actual integration time corresponds to: `number_of_cycles * 2.4ms`.
-    pub fn set_integration_cycles(&mut self, cycles: u16) -> Result<(), Error<E>> {
+    pub fn set_integration_cycles(&mut self, cycles: u16) -> Result<(), Error<I2C::Error>> {
         if cycles > 256 || cycles == 0 {
             return Err(Error::InvalidInputData);
         }
@@ -120,12 +120,12 @@ where
     }
 
     /// Set the RGB converter interrupt clear channel low threshold.
-    pub fn set_rgbc_interrupt_low_threshold(&mut self, threshold: u16) -> Result<(), Error<E>> {
+    pub fn set_rgbc_interrupt_low_threshold(&mut self, threshold: u16) -> Result<(), Error<I2C::Error>> {
         self.write_registers(Register::AILTL, threshold as u8, (threshold >> 8) as u8)
     }
 
     /// Set the RGB converter interrupt clear channel high threshold.
-    pub fn set_rgbc_interrupt_high_threshold(&mut self, threshold: u16) -> Result<(), Error<E>> {
+    pub fn set_rgbc_interrupt_high_threshold(&mut self, threshold: u16) -> Result<(), Error<I2C::Error>> {
         self.write_registers(Register::AIHTL, threshold as u8, (threshold >> 8) as u8)
     }
 
@@ -135,7 +135,7 @@ where
     pub fn set_rgbc_interrupt_persistence(
         &mut self,
         persistence: RgbCInterruptPersistence,
-    ) -> Result<(), Error<E>> {
+    ) -> Result<(), Error<I2C::Error>> {
         use crate::RgbCInterruptPersistence as IP;
         match persistence {
             IP::Every => self.write_register(Register::APERS, 0),
@@ -157,14 +157,14 @@ where
         }
     }
 
-    fn write_register(&mut self, register: u8, value: u8) -> Result<(), Error<E>> {
+    fn write_register(&mut self, register: u8, value: u8) -> Result<(), Error<I2C::Error>> {
         let command = BitFlags::CMD | register;
         self.i2c
             .write(DEVICE_ADDRESS, &[command, value])
             .map_err(Error::I2C)
     }
 
-    fn write_registers(&mut self, register: u8, value0: u8, value1: u8) -> Result<(), Error<E>> {
+    fn write_registers(&mut self, register: u8, value0: u8, value1: u8) -> Result<(), Error<I2C::Error>> {
         let command = BitFlags::CMD | BitFlags::CMD_AUTO_INC | register;
         self.i2c
             .write(DEVICE_ADDRESS, &[command, value0, value1])

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,11 +1,11 @@
 use crate::{
     BitFlags, Error, Register, RgbCGain, RgbCInterruptPersistence, Tcs3472, DEVICE_ADDRESS,
 };
-use embedded_hal::blocking::i2c;
+use embedded_hal::i2c;
 
 impl<I2C, E> Tcs3472<I2C>
 where
-    I2C: i2c::Write<Error = E>,
+    I2C: i2c::I2c<Error = E>,
 {
     /// Enable the device (Power ON).
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@
 #![deny(unsafe_code, missing_docs)]
 #![no_std]
 
-use embedded_hal::blocking::i2c;
+use embedded_hal::i2c;
 
 mod configuration;
 mod interface;
@@ -172,7 +172,7 @@ pub struct Tcs3472<I2C> {
 
 impl<I2C, E> Tcs3472<I2C>
 where
-    I2C: i2c::Write<Error = E>,
+    I2C: i2c::I2c<Error = E>,
 {
     /// Create new instance of the TCS3472 device.
     pub fn new(i2c: I2C) -> Self {

--- a/src/reading.rs
+++ b/src/reading.rs
@@ -1,9 +1,9 @@
 use crate::{AllChannelMeasurement, BitFlags, Error, Register, Tcs3472, DEVICE_ADDRESS};
-use embedded_hal::blocking::i2c;
+use embedded_hal::i2c;
 
 impl<I2C, E> Tcs3472<I2C>
 where
-    I2C: i2c::WriteRead<Error = E>,
+    I2C: i2c::I2c<Error = E>,
 {
     /// Check whether the RGB converter status is valid.
     ///

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,4 @@
-use embedded_hal_mock::i2c::{Mock as I2cMock, Transaction as I2cTrans};
+use embedded_hal_mock::eh1::i2c::{Mock as I2cMock, Transaction as I2cTrans};
 use tcs3472::Tcs3472;
 
 pub const DEV_ADDR: u8 = 0x29;

--- a/tests/configuration.rs
+++ b/tests/configuration.rs
@@ -1,6 +1,6 @@
 mod common;
 use crate::common::{destroy, new, BitFlags, Register, DEV_ADDR};
-use embedded_hal_mock::i2c::Transaction as I2cTrans;
+use embedded_hal_mock::eh1::i2c::Transaction as I2cTrans;
 use tcs3472::{Error, RgbCGain, RgbCInterruptPersistence};
 
 #[test]
@@ -88,6 +88,7 @@ macro_rules! set_invalid_param_test {
                 Err(Error::InvalidInputData) => (),
                 _ => panic!(),
             }
+            destroy(dev);
         }
     };
 }

--- a/tests/reading.rs
+++ b/tests/reading.rs
@@ -1,6 +1,6 @@
 mod common;
 use crate::common::{destroy, new, BitFlags, Register, DEV_ADDR};
-use embedded_hal_mock::i2c::Transaction as I2cTrans;
+use embedded_hal_mock::eh1::i2c::Transaction as I2cTrans;
 
 #[test]
 fn can_read_rgbc_status_not_valid() {


### PR DESCRIPTION
These changed worked for me to be able to use `shared-bus` for multiple I²C devices at once.